### PR TITLE
Adding executable CLI scripts for minification

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,5 +24,6 @@
         "psr-4": {
             "MatthiasMullie\\Minify\\": "src/"
         }
-    }
+    },
+    "bin": ["src/bin/minifycss", "src/bin/minifyjs"]
 }

--- a/src/bin/minifycss
+++ b/src/bin/minifycss
@@ -1,0 +1,40 @@
+#!/usr/bin/env php
+<?php
+use MatthiasMullie\Minify;
+
+// Command line utility to minify CSS
+if (file_exists(__DIR__ . '/../../../../autoload.php')) {
+    // if composer install
+    require_once __DIR__ . '/../../../../autoload.php';
+} else {
+    require_once __DIR__ . '/../Minify.php';
+    require_once __DIR__ . '/../CSS.php';
+    require_once __DIR__ . '/../Exception.php';
+}
+
+error_reporting(E_ALL);
+// Check php setup for cli arguments
+if (!isset($_SERVER['argv']) && !isset($argv)) {
+    fwrite(STDERR, 'Please enable the "register_argc_argv" directive in your php.ini' . PHP_EOL);
+    exit(1);
+} elseif (!isset($argv)) {
+    $argv = $_SERVER['argv'];
+}
+// check if script run in cli environment
+if ('cli' !== php_sapi_name()) {
+    fwrite(STDERR, $argv[1] . ' must be run in the command line.' . PHP_EOL);
+    exit(1);
+}
+// check if source file exists
+if (!file_exists($argv[1])) {
+    fwrite(STDERR, 'Source file "' . $argv[1] . '" not found !' . PHP_EOL);
+    exit(1);
+}
+
+try {
+    $minifier    = new Minify\CSS($argv[1]);
+    echo $minifier->minify();
+} catch (Exception $e) {
+     fwrite(STDERR, $e->getMessage(), PHP_EOL);
+    exit(1);
+}

--- a/src/bin/minifyjs
+++ b/src/bin/minifyjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env php
+<?php
+use MatthiasMullie\Minify;
+
+// Command line utility to minify JS
+if (file_exists(__DIR__ . '/../../../../autoload.php')) {
+    // if composer install
+    require_once __DIR__ . '/../../../../autoload.php';
+} else {
+    require_once __DIR__ . '/../Minify.php';
+    require_once __DIR__ . '/../JS.php';
+    require_once __DIR__ . '/../Exception.php';
+}
+
+error_reporting(E_ALL);
+// Check php setup for cli arguments
+if (!isset($_SERVER['argv']) && !isset($argv)) {
+    fwrite(STDERR, 'Please enable the "register_argc_argv" directive in your php.ini' . PHP_EOL);
+    exit(1);
+} elseif (!isset($argv)) {
+    $argv = $_SERVER['argv'];
+}
+// check if script run in cli environment
+if ('cli' !== php_sapi_name()) {
+    fwrite(STDERR, $argv[1] . ' must be run in the command line.' . PHP_EOL);
+    exit(1);
+}
+// check if source file exists
+if (!file_exists($argv[1])) {
+    fwrite(STDERR, 'Source file "' . $argv[1] . '" not found !' . PHP_EOL);
+    exit(1);
+}
+
+try {
+    $minifier    = new Minify\JS($argv[1]);
+    echo $minifier->minify();
+} catch (Exception $e) {
+    fwrite(STDERR, $e->getMessage(), PHP_EOL);
+    exit(1);
+}


### PR DESCRIPTION
Adds two simple scripts to be used via CLI to minify CSS or JS files. The scripts are really basic, they just take the file to be minified as argument and output the minified content to stdout.
I use these scripts :
- As File watchers in PHPStorm to minify my CSS and JS files upon modification so that I can test the output locally before pushing my modifications to the server
- In my deployment script on my servers when they receive a push from the repository