### PR TITLE
Removed huge regex and replaced with strtr call

### DIFF
--- a/src/Minify.php
+++ b/src/Minify.php
@@ -327,26 +327,7 @@ abstract class Minify
             return $content;
         }
 
-        // PHP only supports $this inside anonymous functions since 5.4
-        $minifier = $this;
-        $callback = function ($match) use ($minifier) {
-            return $minifier->extracted[$match[0]];
-        };
-
-        /*
-         * I basically want a str_replace to put back all of the extracted data.
-         * However, str_replace iteratively goes over the full content for every
-         * value, which means that if I've replaced the first extracted thingy,
-         * it will again search the full content for the second extracted thing.
-         * Which means that, if the original value for the first extract looks
-         * similar to a placeholder that has yet to be restored, that value
-         * would get replaced.
-         * Instead, I'll go a preg_replace, which just processes the content
-         * until it finds a match, replaces that, and continues from that point.
-         */
-        $delimiter = array_fill(0, count($this->extracted), '/');
-        $keys = array_map('preg_quote', array_keys($this->extracted), $delimiter);
-        $content = preg_replace_callback('/(' . implode('|', $keys) . ')/', $callback, $content);
+        $content = strtr($content, $this->extracted);
 
         $this->extracted = array();
 


### PR DESCRIPTION
You used preg_replace to restore extracted placeholders into content to prevent replacing content of already replaced placeholders. But on large files (I tried to merge and minify whole JS project) PHP crashes with error "Compilation failed: regular expression is too large". For my not-so-huge project that was 5000+ placeholders.
This whole process with regex and callback can be replaced with just a single call of strtr() - it accepts key-value pairs as argument and replaces keys with values ignoring already replaced ones. This method works without any error.
http://php.net/manual/en/function.strtr.php - example 2, if more information needed.