### PR TITLE
Preserve for-loop semicolons when 2nd statement is empty

### DIFF
--- a/src/JS.php
+++ b/src/JS.php
@@ -285,8 +285,8 @@ class JS extends Minify
         $content = preg_replace('/\s+('.implode('|', $after).')(?=([;\{\s]|$))/', ' \\1', $content);
 
         // get rid of double semicolons, except when followed by closing-),
-        // where semicolons can be used like: "for(v=1,_=b;;)"
-        $content = preg_replace('/;+(?!\))/', ';', $content);
+        // where semicolons can be used like: "for(v=1,_=b;;)" or "for(v=1;;v++)"
+        $content = preg_replace('/;+(?![^;]*\))/', ';', $content);
 
         /*
          * Next, we'll be removing all semicolons where ASI kicks in.

--- a/tests/js/JSTest.php
+++ b/tests/js/JSTest.php
@@ -120,6 +120,10 @@ class JSTest extends PHPUnit_Framework_TestCase
         );
 
         $tests[] = array(
+          'for ( i = 0; ; i++ ) statement',
+          'for(i=0;;i++)statement',
+        );
+        $tests[] = array(
             'for (i = 0; (i < 10); i++) statement',
             'for(i=0;(i<10);i++)statement',
         );


### PR DESCRIPTION
To resolve issue #70 