### PR TITLE
Prevent error determining if path or content

### DIFF
--- a/src/Minify.php
+++ b/src/Minify.php
@@ -86,7 +86,7 @@ abstract class Minify
     protected function load($data)
     {
         // check if the data is a file
-        if (strpos($file, "\n") === false && file_exists($data) && is_file($data)) {
+        if (strpos($data, "\n") === false && file_exists($data) && is_file($data)) {
             $data = file_get_contents($data);
 
             // strip BOM, if any

--- a/src/Minify.php
+++ b/src/Minify.php
@@ -86,7 +86,7 @@ abstract class Minify
     protected function load($data)
     {
         // check if the data is a file
-        if (file_exists($data) && is_file($data)) {
+        if (strpos($file, "\n") === false && file_exists($data) && is_file($data)) {
             $data = file_get_contents($data);
 
             // strip BOM, if any

--- a/src/Minify.php
+++ b/src/Minify.php
@@ -86,7 +86,7 @@ abstract class Minify
     protected function load($data)
     {
         // check if the data is a file
-        if (strpos($data, "\n") === false && file_exists($data) && is_file($data)) {
+        if (strpos($data, "{") === false && file_exists($data) && is_file($data)) {
             $data = file_get_contents($data);
 
             // strip BOM, if any


### PR DESCRIPTION
Previously the following error was thrown when passing `$data` over the filesystem file name limit:

```
file_exists(): File name is longer than the maximum allowed path length on this platform
```