### PR TITLE
Feature: Add ability to pass an array as an argument

### DIFF
--- a/src/Minify.php
+++ b/src/Minify.php
@@ -61,7 +61,7 @@ abstract class Minify
         // not used (we're using func_get_args instead to support overloading),
         // but it still needs to be defined because it makes no sense to have
         // this function without argument :)
-        $args = array($data) + func_get_args();
+        $args = (array) $data + func_get_args();
 
         // this method can be overloaded
         foreach ($args as $data) {

--- a/tests/css/CSSTest.php
+++ b/tests/css/CSSTest.php
@@ -42,13 +42,8 @@ class CSSTest extends PHPUnit_Framework_TestCase
      */
     public function minify($input, $expected)
     {
-        $input = (array) $input;
-
-        foreach ($input as $css) {
-            $this->minifier->add($css);
-        }
+        $this->minifier->add($input);
         $result = $this->minifier->minify();
-
         $this->assertEquals($expected, $result);
     }
 
@@ -126,6 +121,16 @@ class CSSTest extends PHPUnit_Framework_TestCase
     public function dataProvider()
     {
         $tests = array();
+
+        // passing in an array of css inputs
+        $tests[] = array(
+            [
+                __DIR__.'/sample/combine_imports/index.css',
+                __DIR__.'/sample/bom/bom.css',
+                'p { width: 55px , margin: 0 0 0 0}',
+            ],
+            'body{color:red}body{color:red}p{width:55px,margin:0 0 0 0}',
+        );
 
         // try importing, with both @import syntax types & media queries
         $tests[] = array(

--- a/tests/js/JSTest.php
+++ b/tests/js/JSTest.php
@@ -42,12 +42,8 @@ class JSTest extends PHPUnit_Framework_TestCase
      */
     public function minify($input, $expected)
     {
-        $input = (array) $input;
 
-        foreach ($input as $js) {
-            $this->minifier->add($js);
-        }
-
+        $this->minifier->add($input);
         $result = $this->minifier->minify();
 
         $this->assertEquals($expected, $result);
@@ -59,6 +55,25 @@ class JSTest extends PHPUnit_Framework_TestCase
     public function dataProvider()
     {
         $tests = array();
+
+        // adding multiple files
+        $tests[] = array(
+            [
+                __DIR__.'/sample/source/script1.js',
+                __DIR__.'/sample/source/script2.js'
+            ],
+            'var test=1;var test=2',
+        );
+
+        // adding multiple files and string
+        $tests[] = array(
+            [
+                __DIR__.'/sample/source/script1.js',
+                'console.log(test)',
+                __DIR__.'/sample/source/script2.js'
+            ],
+            'var test=1;console.log(test);var test=2',
+        );
 
         // escaped quotes should not terminate string
         $tests[] = array(


### PR DESCRIPTION
**Version:** 1.3.35

**Attempted:** I wanted to pass in an array of assets like so

```
$config['assets.css'] = [
            "themes/" . $config['theme'] . "/css/bootstrap.min.css",
            "themes/" . $config['theme'] . "/css/bootstrap-select.min.css",
            "themes/" . $config['theme'] . "/css/app.css"
        ];

$config['assets.min.css'] = "themes/" . $config['theme'] . "/min/min.css"

$config['assets.js'] = [
            "themes/" . $config['theme'] . "/js/lib/jquery-1.10.2.min.js",
            "themes/" . $config['theme'] . "/js/lib/idletimer.js",
            "themes/" . $config['theme'] . "/js/lib/mustache.js",
            "themes/" . $config['theme'] . "/js/lib/maskedinput-1.3.1.min.js",
            "themes/" . $config['theme'] . "/js/lib/bootstrap.min.js",
            "themes/" . $config['theme'] . "/js/lib/bootstrap-select.min.js",
            "themes/" . $config['theme'] . "/js/lib/custom.js",
            "themes/" . $config['theme'] . "/js/lib/liveperson.js",
            "themes/" . $config['theme'] . "/js/app.js"
        ];

$config['assets.min.js'] = "themes/" . $config['theme'] . "/min/min.js"
```

and then use like so

```
        $minCSS = new \MatthiasMullie\Minify\CSS(Config::get('assets.css'));
        $minJS  = new \MatthiasMullie\Minify\JS(Config::get('assets.js'));

        $minCSS->minify(Config::get('assets.min.css');
        $minJS->minify(Config::get('assets.min.js');

```

**Result:**
```
Type: ErrorException
Code: 8
Message: Array to string conversion
File: /vendor/matthiasmullie/minify/src/Minify.php
Line: 69
```

**Expected:** I expected the array to be accepted as a parameter

**Details:**
add() will now accept an array of js/css files, useful when your list of assets live in a config file
Add unit tests
Modify test harness