### PR TITLE
replace CR linefeeds etc. when loading files

### DIFF
--- a/src/Minify.php
+++ b/src/Minify.php
@@ -154,6 +154,9 @@ abstract class Minify
         if ($this->canImportFile($data)) {
             $data = file_get_contents($data);
 
+            // replace CR linefeeds etc.
+            $data = preg_replace('~\R~', "\n", $data);
+            
             // strip BOM, if any
             if (substr($data, 0, 3) == "\xef\xbb\xbf") {
                 $data = substr($data, 3);


### PR DESCRIPTION
Replace "wrong" linefeeds, e.g. if a file was saved on MacOS with CR only