### PR TITLE
Implemented the possibility to turn off the conversion of relative paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,16 @@ Minifies and optionally saves to a file, just like `minify()`, but it also `gzen
 $minifier->gzip('/target/path.js');
 ```
 
+### setFixRelativePath($value) *(CSS only)*
+
+The CSS minifier will automatically convert relative path to a combination between source and destination paths. But in some cases this can cause an issue and return a path inaccessible to the user.
+
+This method allows to turn of the conversion of relative paths inside the CSS by setting false. The default size is true.
+
+```php
+$minifier->setFixRelativePath(false);
+```
+
 ### setMaxImportSize($size) *(CSS only)*
 
 The CSS minifier will automatically embed referenced files (like images, fonts, ...) into the minified CSS, so they don't have to be fetched over multiple connections.

--- a/src/CSS.php
+++ b/src/CSS.php
@@ -18,6 +18,11 @@ use MatthiasMullie\PathConverter\Converter;
 class CSS extends Minify
 {
     /**
+     * @var bool
+     */
+    protected $fixRelativePath = true;
+
+    /**
      * @var int
      */
     protected $maxImportSize = 5;
@@ -37,6 +42,16 @@ class CSS extends Minify
         'tiff' => 'image/tiff',
         'xbm' => 'image/x-xbitmap',
     );
+
+    /**
+     * Set the condition to fix relative path.
+     *
+     * @param bool $value
+     */
+    public function setFixRelativePath($value)
+    {
+        $this->fixRelativePath = $value;
+    }
 
     /**
      * Set the maximum size if files to be imported.
@@ -455,7 +470,9 @@ class CSS extends Minify
             $url = $params ? substr($match['path'], 0, -strlen($params)) : $match['path'];
 
             // fix relative url
-            $url = $converter->convert($url);
+            if ($this->fixRelativePath) {
+                $url = $converter->convert($url);
+            }
 
             // now that the path has been converted, re-apply GET-params
             $url .= $params;


### PR DESCRIPTION
In some cases, the relative paths is converted in inaccessible URI to the user.

- Added property fixRelativePath to CSS class;
- Added method setFixRelativePath to CSS class;