### PR TITLE
Require psr/cache

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     "require": {
         "php": ">=5.3.0",
         "ext-pcre": "*",
-        "matthiasmullie/path-converter": "~1.1"
+        "matthiasmullie/path-converter": "~1.1",
+        "psr/cache": "^1.0"
     },
     "require-dev": {
         "matthiasmullie/scrapbook": "~1.0",


### PR DESCRIPTION
Hello @matthiasmullie
As [MatthiasMullie\Minify\Minify](https://github.com/matthiasmullie/minify/blob/b431a11bc55f3dd33de8552275d13821ae8e2bdb/src/Minify.php#L6) uses `Psr\Cache\CacheItemInterface` it would be better to require `psr/cache`. This does not seem to have been noticeable yet, cause [matthiasmullie/scrapbook](https://github.com/matthiasmullie/scrapbook) is in `require-dev` and `matthiasmullie/scrapbook` requires `psr/cache`. But an composer installation of `matthiasmullie/minify` with the parameter `--update-no-dev` will miss the installation of `psr/cache`.

Best Regards
Gordon