### PR TITLE
Use travis dist: trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+
 language: php
 
 php:


### PR DESCRIPTION
Hello @matthiasmullie 
[Travis Jobs](https://travis-ci.org/matthiasmullie/minify/jobs/238351651) are failing with the following error ```HHVM is no longer supported on Ubuntu Precise. Please consider using Trusty with `dist: trusty`.```.