### PR TITLE
Added an option to skip already minified sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /build
 /docs
 /vendor
+/.idea
 composer.lock
-

--- a/README.md
+++ b/README.md
@@ -133,6 +133,21 @@ $minifier->setImportExtensions($extensions);
 ```
 
 
+### setOptimalizationLevel($level)
+
+*Minify::LEVEL_AUTODETECT* (default): The minifier will detect minified sources based on filename and will not minify them again. External sources in CSS are always embedded into minified CSS.
+
+*Minify::LEVEL_JOIN*: All files will be just joined together and external sources will be embedded if configured.
+
+*Minify::LEVEL_FULL*: All files will be minified (old behaviour).
+
+Speed optimalization on selected minified bootstrap sources are (approx): 100% on full, 35% on autodetect, 10% on join.
+
+```php
+$minifier->setOptimalizationLevel(Minify\Minify::LEVEL_FULL);
+```
+
+
 ## Installation
 
 Simply add a dependency on matthiasmullie/minify to your composer.json file if you use [Composer](https://getcomposer.org/) to manage the dependencies of your project:

--- a/bin/minifycss
+++ b/bin/minifycss
@@ -4,8 +4,11 @@ use MatthiasMullie\Minify;
 
 // command line utility to minify CSS
 if (file_exists(__DIR__ . '/../../../autoload.php')) {
-    // if composer install
-    require_once __DIR__ . '/../../../autoload.php';
+	// if composer install
+	require_once __DIR__ . '/../../../autoload.php';
+} else if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
+    // if standalone composer install
+    require_once __DIR__ . '/../vendor/autoload.php';
 } else {
     require_once __DIR__ . '/../src/Minify.php';
     require_once __DIR__ . '/../src/CSS.php';

--- a/bin/minifyjs
+++ b/bin/minifyjs
@@ -6,6 +6,9 @@ use MatthiasMullie\Minify;
 if (file_exists(__DIR__ . '/../../../autoload.php')) {
     // if composer install
     require_once __DIR__ . '/../../../autoload.php';
+} else if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
+    // if standalone composer install
+    require_once __DIR__ . '/../vendor/autoload.php';
 } else {
     require_once __DIR__ . '/../src/Minify.php';
     require_once __DIR__ . '/../src/JS.php';

--- a/src/CSS.php
+++ b/src/CSS.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * CSS Minifier
+ * CSS Minifier.
  *
  * Please report bugs on https://github.com/matthiasmullie/minify/issues
  *
@@ -16,11 +16,10 @@ use MatthiasMullie\PathConverter\ConverterInterface;
 use MatthiasMullie\PathConverter\Converter;
 
 /**
- * CSS minifier
+ * CSS minifier.
  *
  * Please report bugs on https://github.com/matthiasmullie/minify/issues
  *
- * @package Minify
  * @author Matthias Mullie <minify@mullie.eu>
  * @author Tijs Verkoyen <minify@verkoyen.eu>
  * @copyright Copyright (c) 2012, Matthias Mullie. All rights reserved
@@ -295,6 +294,9 @@ class CSS extends Minify
     {
         $content = '';
 
+        $this->extractStrings();
+        $this->stripComments();
+
         // loop CSS data (raw data and files)
         foreach ($this->data as $source => $css) {
             /*
@@ -303,21 +305,23 @@ class CSS extends Minify
              * we should leave it alone. E.g.:
              * p { content: "a   test" }
              */
-            $this->extractStrings();
-            $this->stripComments();
-            $css = $this->replace($css);
-
-            $css = $this->stripWhitespace($css);
-            $css = $this->shortenHex($css);
-            $css = $this->shortenZeroes($css);
-            $css = $this->shortenFontWeights($css);
-            $css = $this->stripEmptyTags($css);
-
-            // restore the string we've extracted earlier
-            $css = $this->restoreExtractedData($css);
-
             $source = is_int($source) ? '' : $source;
             $parents = $source ? array_merge($parents, array($source)) : $parents;
+            $fully = $this->shouldMinifyFully($source);
+
+            if ($fully) {
+                $css = $this->replace($css);
+
+                $css = $this->stripWhitespace($css);
+                $css = $this->shortenHex($css);
+                $css = $this->shortenZeroes($css);
+                $css = $this->shortenFontWeights($css);
+                $css = $this->stripEmptyTags($css);
+
+                // restore the string we've extracted earlier
+                $css = $this->restoreExtractedData($css);
+            }
+
             $css = $this->combineImports($source, $css, $parents);
             $css = $this->importFiles($source, $css);
 
@@ -454,8 +458,9 @@ class CSS extends Minify
              * @see https://github.com/matthiasmullie/minify/issues/193
              */
             $url = trim($url);
+
             if (preg_match('/[\s\)\'"#\x{7f}-\x{9f}]/u', $url)) {
-                $url = $match['quotes'] . $url . $match['quotes'];
+                $url = $match['quotes'].$url.$match['quotes'];
             }
 
             // build replacement
@@ -666,7 +671,7 @@ class CSS extends Minify
     /**
      * Find all `calc()` occurrences.
      *
-     * @param string $content The CSS content to find `calc()`s in.
+     * @param string $content The CSS content to find `calc()`s in
      *
      * @return string[]
      */
@@ -680,11 +685,11 @@ class CSS extends Minify
             $expr = '';
             $opened = 0;
 
-            for ($i = 0; $i < $length; $i++) {
+            for ($i = 0; $i < $length; ++$i) {
                 $char = $match[1][$i];
                 $expr .= $char;
                 if ($char === '(') {
-                    $opened++;
+                    ++$opened;
                 } elseif ($char === ')' && --$opened === 0) {
                     break;
                 }

--- a/src/JS.php
+++ b/src/JS.php
@@ -190,11 +190,13 @@ class JS extends Minify
                 $js = $this->restoreExtractedData($js);
             }
             if (strlen($js)) {
+                if (!$fully)
+                    $js .= "\n";
                 $content[] = $js;
             }
         }
 
-        return implode(';', $content);
+        return rtrim(implode(';', $content));
     }
 
     /**

--- a/tests/css/CSSTest.php
+++ b/tests/css/CSSTest.php
@@ -83,7 +83,7 @@ class CSSTest extends PHPUnit_Framework_TestCase
      *
      * @test
      *
-     * @expectedException MatthiasMullie\Minify\Exceptions\FileImportException
+     * @expectedException \MatthiasMullie\Minify\Exceptions\FileImportException
      */
     public function fileImportLoop()
     {
@@ -590,55 +590,58 @@ body{
 
         // https://github.com/matthiasmullie/minify/issues/183
         $tests[] = array(
-            ".mce-container,
+            '.mce-container,
 .mce-container *,
 .mce-widget,
 .mce-widget *,
 .mce-reset {
     color: red;
-}",
-            ".mce-container,.mce-container *,.mce-widget,.mce-widget *,.mce-reset{color:red}",
+}',
+            '.mce-container,.mce-container *,.mce-widget,.mce-widget *,.mce-reset{color:red}',
         );
 
         // https://github.com/matthiasmullie/minify/issues/184
         $tests[] = array(
-            ".soliloquy-container, .soliloquy-container * {color:red}",
-            ".soliloquy-container,.soliloquy-container *{color:red}",
+            '.soliloquy-container, .soliloquy-container * {color:red}',
+            '.soliloquy-container,.soliloquy-container *{color:red}',
         );
         $tests[] = array(
-            "p{background: transparent url(images/preloader.gif) no-repeat scroll 50% 50%;}",
-            "p{background:transparent url(images/preloader.gif) no-repeat scroll 50% 50%}",
+            'p{background: transparent url(images/preloader.gif) no-repeat scroll 50% 50%;}',
+            'p{background:transparent url(images/preloader.gif) no-repeat scroll 50% 50%}',
         );
 
         // https://github.com/matthiasmullie/minify/issues/191
         $tests[] = array(
-            "some .weird- selector{display:none}",
-            "some .weird- selector{display:none}",
+            'some .weird- selector{display:none}',
+            'some .weird- selector{display:none}',
         );
         $tests[] = array(
-            "p:nth-child( - n + 3 ){display:none}",
-            "p:nth-child(-n+3){display:none}",
+            'p:nth-child( - n + 3 ){display:none}',
+            'p:nth-child(-n+3){display:none}',
         );
         $tests[] = array(
-            "p:nth-child( + 3 ){display:none}",
-            "p:nth-child(+3){display:none}",
+            'p:nth-child( + 3 ){display:none}',
+            'p:nth-child(+3){display:none}',
         );
         $tests[] = array(
-            "p:nth-child( n + 3 ){display:none}",
-            "p:nth-child(n+3){display:none}",
+            'p:nth-child( n + 3 ){display:none}',
+            'p:nth-child(n+3){display:none}',
         );
         $tests[] = array(
-            "p:nth-child( odd ){display:none}",
-            "p:nth-child(odd){display:none}",
+            'p:nth-child( odd ){display:none}',
+            'p:nth-child(odd){display:none}',
         );
         $tests[] = array(
-            "p:nth-child( n ){display:none}",
-            "p:nth-child(n){display:none}",
+            'p:nth-child( n ){display:none}',
+            'p:nth-child(n){display:none}',
         );
         $tests[] = array(
-            "p:nth-child( -n ){display:none}",
-            "p:nth-child(-n){display:none}",
+            'p:nth-child( -n ){display:none}',
+            'p:nth-child(-n){display:none}',
         );
+
+        // skip minification of minified files
+        $tests[] = array(__DIR__.'/sample/minified_sources/file.min.css', 'body { background: yellow; }');
 
         // https://github.com/matthiasmullie/minify/issues/193
         $tests[] = array(
@@ -711,6 +714,9 @@ body{
 }',
             '#site-header.medium-header .top-col.logo-col{-webkit-flex:auto 0 0;flex:auto 0 0}',
         );
+
+        // skip minification of minified files
+        $tests[] = array(__DIR__.'/sample/minified_sources/file.min.css', 'body { background: yellow; }');
 
         return $tests;
     }

--- a/tests/css/sample/minified_sources/file.min.css
+++ b/tests/css/sample/minified_sources/file.min.css
@@ -1,0 +1,1 @@
+body { background: yellow; }

--- a/tests/js/JSTest.php
+++ b/tests/js/JSTest.php
@@ -1146,7 +1146,7 @@ $the_portfolio.data(\'carouseling\',!0);$active_carousel_group.children().each(f
         // https://github.com/matthiasmullie/minify/issues/204
         $tests[] = array(
             'data = data.replace(this.video.reUrlYoutube, iframeStart + \'//www.youtube.com/embed/$1\' + iframeEnd);',
-            'data=data.replace(this.video.reUrlYoutube,iframeStart+\'//www.youtube.com/embed/$1\'+iframeEnd)'
+            'data=data.replace(this.video.reUrlYoutube,iframeStart+\'//www.youtube.com/embed/$1\'+iframeEnd)',
         );
         $tests[] = array(
             'pattern = /(\/)\'/;
@@ -1218,8 +1218,8 @@ a = \'b\';',
             "inside:{'rule':/@[\w-]+/}",
         );
         $tests[] = array(
-            "(1 + 2) / 3 / 4",
-            "(1+2)/3/4",
+            '(1 + 2) / 3 / 4',
+            '(1+2)/3/4',
         );
 
         // https://github.com/matthiasmullie/minify/issues/221
@@ -1275,6 +1275,10 @@ var largeScreen=2048',
             $content = trim(file_get_contents($file));
             $tests[] = array($content, $content);
         }
+
+        // skip minification of minified files
+        $tests[] = array(__DIR__.'/sample/minified_sources/file.min.js', 'var a = true;');
+
         // update tests' expected results for cross-system compatibility
         foreach ($tests as &$test) {
             if (!empty($test[1])) {

--- a/tests/js/sample/minified_sources/file.min.js
+++ b/tests/js/sample/minified_sources/file.min.js
@@ -1,0 +1,1 @@
+var a = true;


### PR DESCRIPTION
This creates an option to minify sources and skip slow operations on files containing .min. or -min. in its filenames. It's behavior is switchable using a method setOptimalizationLevel. Quick tests added.
Resolves #172