### PR TITLE
Also remove any JS after a comment in the form of /*DEV*/

### DIFF
--- a/src/JS.php
+++ b/src/JS.php
@@ -208,6 +208,9 @@ class JS extends Minify
      */
     public function stripComments()
     {
+        // /*DEV*/ style comments
+        $this->registerPattern('/\/\*DEV\*\/.*$/m', '');
+        
         // single-line comments
         $this->registerPattern('/\/\/.*$/m', '');
 


### PR DESCRIPTION
Using this to log to the console during development, e.g. 
/*DEV*/ console.log("debug information");
Anything after the /*DEV*/ string is removed on minification.