### PR TITLE
Minify customizations

### DIFF
--- a/src/CSS.php
+++ b/src/CSS.php
@@ -287,9 +287,10 @@ class CSS extends Minify
      * Perform CSS optimizations.
      *
      * @param string[optional] $path    Path to write the data to
-     * @param string[]         $parents Parent paths, for circular reference checks
+     * @param string[] $parents Parent paths, for circular reference checks
      *
      * @return string The minified data
+     * @throws FileImportException
      */
     public function execute($path = null, $parents = array())
     {
@@ -336,6 +337,37 @@ class CSS extends Minify
         }
 
         $content = $this->moveImportsToTop($content);
+
+        /*
+         * After getting the merged data of all css files
+         * this method here will remove duplicate css selectors
+         * for instance, a user might add two css files like default.css & default.css?v=1
+         * both files contain the same selectors "body {font-family: xxx}"
+         * this method will deal with those duplicates and remove them from the final content.
+         */
+        $content = $this->removeDuplicates($content);
+
+        return $content;
+    }
+
+    /**
+     * Remove Duplicate CSS Selectors
+     * for example if there is duplicate body{font-size:13px}
+     * this method will return one selector
+     *
+     * @param $content
+     * @return string
+     */
+    private function removeDuplicates($content)
+    {
+
+        // Collect Selectors
+        preg_match_all('/(?ims)([a-z0-9, \s\.\:#_\-@]+)\{([^\}]*)\}/', $content, $selectors);
+
+        if (isset($selectors[0]))
+
+            // return a unique array of selectors and implode it into a string
+            return implode(null, array_unique($selectors[0]));
 
         return $content;
     }

--- a/src/CSS.php
+++ b/src/CSS.php
@@ -375,7 +375,7 @@ class CSS extends Minify
     {
 
         // Collect Selectors
-        preg_match_all('/(?ims)([a-z0-9, \s\.\:#_\-@]+)\{([^\}]*)\}/', $content, $selectors);
+        preg_match_all('/(.*?)\{(.*?)\}/s', $content, $selectors);
 
         if (isset($selectors[0]))
 

--- a/src/CSS.php
+++ b/src/CSS.php
@@ -37,16 +37,16 @@ class CSS extends Minify
      * @var string[] valid import extensions
      */
     protected $importExtensions = array(
-        'gif' => 'data:image/gif',
-        'png' => 'data:image/png',
-        'jpe' => 'data:image/jpeg',
-        'jpg' => 'data:image/jpeg',
+        'gif'  => 'data:image/gif',
+        'png'  => 'data:image/png',
+        'jpe'  => 'data:image/jpeg',
+        'jpg'  => 'data:image/jpeg',
         'jpeg' => 'data:image/jpeg',
-        'svg' => 'data:image/svg+xml',
+        'svg'  => 'data:image/svg+xml',
         'woff' => 'data:application/x-font-woff',
-        'tif' => 'image/tiff',
+        'tif'  => 'image/tiff',
         'tiff' => 'image/tiff',
-        'xbm' => 'image/x-xbitmap',
+        'xbm'  => 'image/x-xbitmap',
     );
 
     /**
@@ -93,7 +93,7 @@ class CSS extends Minify
             }
 
             // add to top
-            $content = implode(';', $matches[2]).';'.trim($content, ';');
+            $content = implode(';', $matches[2]) . ';' . trim($content, ';');
         }
 
         return $content;
@@ -105,8 +105,8 @@ class CSS extends Minify
      * @import's will be loaded and their content merged into the original file,
      * to save HTTP requests.
      *
-     * @param string   $source  The file to combine imports for
-     * @param string   $content The CSS content to combine imports for
+     * @param string $source The file to combine imports for
+     * @param string $content The CSS content to combine imports for
      * @param string[] $parents Parent paths, for circular reference checks
      *
      * @return string
@@ -200,7 +200,7 @@ class CSS extends Minify
         // loop the matches
         foreach ($matches as $match) {
             // get the path for the file that will be imported
-            $importPath = dirname($source).'/'.$match['path'];
+            $importPath = dirname($source) . '/' . $match['path'];
 
             // only replace the import with the content if we can grab the
             // content of the file
@@ -211,7 +211,7 @@ class CSS extends Minify
             // check if current file was not imported previously in the same
             // import chain.
             if (in_array($importPath, $parents)) {
-                throw new FileImportException('Failed to import file "'.$importPath.'": circular reference detected.');
+                throw new FileImportException('Failed to import file "' . $importPath . '": circular reference detected.');
             }
 
             // grab referenced file & minify it (which may include importing
@@ -221,7 +221,7 @@ class CSS extends Minify
 
             // check if this is only valid for certain media
             if (!empty($match['media'])) {
-                $importContent = '@media '.$match['media'].'{'.$importContent.'}';
+                $importContent = '@media ' . $match['media'] . '{' . $importContent . '}';
             }
 
             // add to replacement array
@@ -239,7 +239,7 @@ class CSS extends Minify
      * @url(image.jpg) images will be loaded and their content merged into the
      * original file, to save HTTP requests.
      *
-     * @param string $source  The file to import files for
+     * @param string $source The file to import files for
      * @param string $content The CSS content to import files for
      *
      * @return string
@@ -260,7 +260,7 @@ class CSS extends Minify
 
                 // get the path for the file that will be imported
                 $path = $match[2];
-                $path = dirname($source).'/'.$path;
+                $path = dirname($source) . '/' . $path;
 
                 // only replace the import with the content if we're able to get
                 // the content of the file, and it's relatively small
@@ -271,7 +271,7 @@ class CSS extends Minify
 
                     // build replacement
                     $search[] = $match[0];
-                    $replace[] = 'url('.$this->importExtensions[$extension].';base64,'.$importContent.')';
+                    $replace[] = 'url(' . $this->importExtensions[$extension] . ';base64,' . $importContent . ')';
                 }
             }
 
@@ -304,15 +304,28 @@ class CSS extends Minify
              * we should leave it alone. E.g.:
              * p { content: "a   test" }
              */
+
             $this->extractStrings();
-            $this->stripComments();
+
+            if ($this->options['css-strip-comments'] === true)
+                $this->stripComments();
+
             $css = $this->replace($css);
 
-            $css = $this->stripWhitespace($css);
-            $css = $this->shortenHex($css);
-            $css = $this->shortenZeroes($css);
-            $css = $this->shortenFontWeights($css);
-            $css = $this->stripEmptyTags($css);
+            if ($this->options['css-strip-whitespace'] === true)
+                $css = $this->stripWhitespace($css);
+
+            if ($this->options['css-shorten-hex'] === true)
+                $css = $this->shortenHex($css);
+
+            if ($this->options['css-shorten-zeroes'] === true)
+                $css = $this->shortenZeroes($css);
+
+            if ($this->options['css-shorten-font-weights'] === true)
+                $css = $this->shortenFontWeights($css);
+
+            if ($this->options['css-strip-empty-tags'] === true)
+                $css = $this->stripEmptyTags($css);
 
             // restore the string we've extracted earlier
             $css = $this->restoreExtractedData($css);
@@ -379,7 +392,7 @@ class CSS extends Minify
      * (e.g. ../../images/image.gif, if the new CSS file is 1 folder deeper).
      *
      * @param ConverterInterface $converter Relative path converter
-     * @param string             $content   The CSS content to update relative urls for
+     * @param string $content The CSS content to update relative urls for
      *
      * @return string
      */
@@ -493,9 +506,9 @@ class CSS extends Minify
             // build replacement
             $search[] = $match[0];
             if ($type === 'url') {
-                $replace[] = 'url('.$url.')';
+                $replace[] = 'url(' . $url . ')';
             } elseif ($type === 'import') {
-                $replace[] = '@import "'.$url.'"';
+                $replace[] = '@import "' . $url . '"';
             }
         }
 
@@ -535,7 +548,7 @@ class CSS extends Minify
             '#FFC0CB' => 'pink',
             '#DDA0DD' => 'plum',
             '#800080' => 'purple',
-            '#F00' => 'red',
+            '#F00'    => 'red',
             '#FA8072' => 'salmon',
             '#A0522D' => 'sienna',
             '#C0C0C0' => 'silver',
@@ -547,7 +560,7 @@ class CSS extends Minify
         );
 
         return preg_replace_callback(
-            '/(?<=[: ])('.implode(array_keys($colors), '|').')(?=[; }])/i',
+            '/(?<=[: ])(' . implode(array_keys($colors), '|') . ')(?=[; }])/i',
             function ($match) use ($colors) {
                 return $colors[strtoupper($match[0])];
             },
@@ -566,14 +579,14 @@ class CSS extends Minify
     {
         $weights = array(
             'normal' => 400,
-            'bold' => 700,
+            'bold'   => 700,
         );
 
         $callback = function ($match) use ($weights) {
-            return $match[1].$weights[$match[2]];
+            return $match[1] . $weights[$match[2]];
         };
 
-        return preg_replace_callback('/(font-weight\s*:\s*)('.implode('|', array_keys($weights)).')(?=[;}])/', $callback, $content);
+        return preg_replace_callback('/(font-weight\s*:\s*)(' . implode('|', array_keys($weights)) . ')(?=[;}])/', $callback, $content);
     }
 
     /**
@@ -609,19 +622,19 @@ class CSS extends Minify
         // practice, Webkit (especially Safari) seems to stumble over at least
         // 0%, potentially other units as well. Only stripping 'px' for now.
         // @see https://github.com/matthiasmullie/minify/issues/60
-        $content = preg_replace('/'.$before.'(-?0*(\.0+)?)(?<=0)px'.$after.'/', '\\1', $content);
+        $content = preg_replace('/' . $before . '(-?0*(\.0+)?)(?<=0)px' . $after . '/', '\\1', $content);
 
         // strip 0-digits (.0 -> 0)
-        $content = preg_replace('/'.$before.'\.0+'.$units.'?'.$after.'/', '0\\1', $content);
+        $content = preg_replace('/' . $before . '\.0+' . $units . '?' . $after . '/', '0\\1', $content);
         // strip trailing 0: 50.10 -> 50.1, 50.10px -> 50.1px
-        $content = preg_replace('/'.$before.'(-?[0-9]+\.[0-9]+)0+'.$units.'?'.$after.'/', '\\1\\2', $content);
+        $content = preg_replace('/' . $before . '(-?[0-9]+\.[0-9]+)0+' . $units . '?' . $after . '/', '\\1\\2', $content);
         // strip trailing 0: 50.00 -> 50, 50.00px -> 50px
-        $content = preg_replace('/'.$before.'(-?[0-9]+)\.0+'.$units.'?'.$after.'/', '\\1\\2', $content);
+        $content = preg_replace('/' . $before . '(-?[0-9]+)\.0+' . $units . '?' . $after . '/', '\\1\\2', $content);
         // strip leading 0: 0.1 -> .1, 01.1 -> 1.1
-        $content = preg_replace('/'.$before.'(-?)0+([0-9]*\.[0-9]+)'.$units.'?'.$after.'/', '\\1\\2\\3', $content);
+        $content = preg_replace('/' . $before . '(-?)0+([0-9]*\.[0-9]+)' . $units . '?' . $after . '/', '\\1\\2\\3', $content);
 
         // strip negative zeroes (-0 -> 0) & truncate zeroes (00 -> 0)
-        $content = preg_replace('/'.$before.'-?0+'.$units.'?'.$after.'/', '0\\1', $content);
+        $content = preg_replace('/' . $before . '-?0+' . $units . '?' . $after . '/', '0\\1', $content);
 
         // IE doesn't seem to understand a unitless flex-basis value (correct -
         // it goes against the spec), so let's add it in again (make it `%`,
@@ -687,7 +700,7 @@ class CSS extends Minify
         // not in things like `calc(3px + 2px)`, shorthands like `3px -2px`, or
         // selectors like `div.weird- p`
         $pseudos = array('nth-child', 'nth-last-child', 'nth-last-of-type', 'nth-of-type');
-        $content = preg_replace('/:('.implode('|', $pseudos).')\(\s*([+-]?)\s*(.+?)\s*([+-]?)\s*(.*?)\s*\)/', ':$1($2$3$4$5)', $content);
+        $content = preg_replace('/:(' . implode('|', $pseudos) . ')\(\s*([+-]?)\s*(.+?)\s*([+-]?)\s*(.*?)\s*\)/', ':$1($2$3$4$5)', $content);
 
         // remove semicolon/whitespace followed by closing bracket
         $content = str_replace(';}', '}', $content);
@@ -722,7 +735,7 @@ class CSS extends Minify
                 }
             }
 
-            $results['calc('.count($results).')'] = 'calc'.$expr;
+            $results['calc(' . count($results) . ')'] = 'calc' . $expr;
         }
 
         return $results;

--- a/src/Minify.php
+++ b/src/Minify.php
@@ -60,7 +60,6 @@ abstract class Minify
                 $this->options[$key] = $value;
         }
 
-
         return $this;
     }
 

--- a/src/Minify.php
+++ b/src/Minify.php
@@ -8,6 +8,7 @@
  * @copyright Copyright (c) 2012, Matthias Mullie. All rights reserved
  * @license MIT License
  */
+
 namespace MatthiasMullie\Minify;
 
 use MatthiasMullie\Minify\Exceptions\IOException;
@@ -25,6 +26,44 @@ use Psr\Cache\CacheItemInterface;
  */
 abstract class Minify
 {
+
+    /**
+     * Default Minify Options list
+     *
+     * @var array
+     */
+    public $options = array(
+        'css-strip-comments'       => true,
+        'css-strip-whitespace'     => true,
+        'css-shorten-hex'          => true,
+        'css-shorten-zeroes'       => true,
+        'css-shorten-font-weights' => true,
+        'css-strip-empty-tags'     => true,
+    );
+
+    /**
+     * Set Minify options
+     * useful for class customizations.
+     *
+     * @param $key
+     * @param null $value
+     * @return $this
+     */
+    public function setOptions($key, $value = null)
+    {
+
+        if (is_array($key)) {
+            foreach ($key as $_key => $_value)
+                $this->setOptions($_key, $_value);
+        } else {
+            if (array_key_exists($key, $this->options))
+                $this->options[$key] = $value;
+        }
+
+
+        return $this;
+    }
+
     /**
      * The data to be minified.
      *
@@ -82,7 +121,7 @@ abstract class Minify
             }
 
             // redefine var
-            $data = (string) $data;
+            $data = (string)$data;
 
             // load data
             $value = $this->load($data);
@@ -105,6 +144,7 @@ abstract class Minify
      * @param string[optional] $path Path to write the data to
      *
      * @return string The minified data
+     * @throws IOException
      */
     public function minify($path = null)
     {
@@ -122,9 +162,9 @@ abstract class Minify
      * Minify & gzip the data & (optionally) saves it to a file.
      *
      * @param string[optional] $path  Path to write the data to
-     * @param int[optional]    $level Compression level, from 0 to 9
-     *
+     * @param int $level
      * @return string The minified & gzipped data
+     * @throws IOException
      */
     public function gzip($path = null, $level = 9)
     {
@@ -189,7 +229,7 @@ abstract class Minify
      * Save to file.
      *
      * @param string $content The minified data
-     * @param string $path    The path to save the minified data to
+     * @param string $path The path to save the minified data to
      *
      * @throws IOException
      */
@@ -205,7 +245,7 @@ abstract class Minify
     /**
      * Register a pattern to execute against the source content.
      *
-     * @param string          $pattern     PCRE pattern
+     * @param string $pattern PCRE pattern
      * @param string|callable $replacement Replacement value for matched pattern
      */
     protected function registerPattern($pattern, $replacement = '')
@@ -281,8 +321,8 @@ abstract class Minify
 
             // figure out which part of the string was unmatched; that's the
             // part we'll execute the patterns on again next
-            $content = (string) substr($content, $discardLength);
-            $unmatched = (string) substr($content, strpos($content, $match) + strlen($match));
+            $content = (string)substr($content, $discardLength);
+            $unmatched = (string)substr($content, strpos($content, $match) + strlen($match));
 
             // move the replaced part to $processed and prepare $content to
             // again match batch of patterns against
@@ -306,9 +346,9 @@ abstract class Minify
      * This function will be called plenty of times, where $content will always
      * move up 1 character.
      *
-     * @param string          $pattern     Pattern to match
+     * @param string $pattern Pattern to match
      * @param string|callable $replacement Replacement value
-     * @param string          $content     Content to match pattern against
+     * @param string $content Content to match pattern against
      *
      * @return string
      */
@@ -352,8 +392,8 @@ abstract class Minify
             }
 
             $count = count($minifier->extracted);
-            $placeholder = $match[1].$placeholderPrefix.$count.$match[1];
-            $minifier->extracted[$placeholder] = $match[1].$match[2].$match[1];
+            $placeholder = $match[1] . $placeholderPrefix . $count . $match[1];
+            $minifier->extracted[$placeholder] = $match[1] . $match[2] . $match[1];
 
             return $placeholder;
         };
@@ -370,7 +410,7 @@ abstract class Minify
          * considered as escape-char (times 2) and to get it in the regex,
          * escaped (times 2)
          */
-        $this->registerPattern('/(['.$chars.'])(.*?(?<!\\\\)(\\\\\\\\)*+)\\1/s', $callback);
+        $this->registerPattern('/([' . $chars . '])(.*?(?<!\\\\)(\\\\\\\\)*+)\\1/s', $callback);
     }
 
     /**
@@ -430,7 +470,7 @@ abstract class Minify
     protected function openFileForWriting($path)
     {
         if (($handler = @fopen($path, 'w')) === false) {
-            throw new IOException('The file "'.$path.'" could not be opened for writing. Check if PHP has enough permissions.');
+            throw new IOException('The file "' . $path . '" could not be opened for writing. Check if PHP has enough permissions.');
         }
 
         return $handler;
@@ -440,15 +480,15 @@ abstract class Minify
      * Attempts to write $content to the file specified by $handler. $path is used for printing exceptions.
      *
      * @param resource $handler The resource to write to
-     * @param string   $content The content to write
-     * @param string   $path    The path to the file (for exception printing only)
+     * @param string $content The content to write
+     * @param string $path The path to the file (for exception printing only)
      *
      * @throws IOException
      */
     protected function writeToFile($handler, $content, $path = '')
     {
         if (($result = @fwrite($handler, $content)) === false || ($result < strlen($content))) {
-            throw new IOException('The file "'.$path.'" could not be written to. Check your disk space and file permissions.');
+            throw new IOException('The file "' . $path . '" could not be written to. Check your disk space and file permissions.');
         }
     }
 }


### PR DESCRIPTION
## Adding Some customization to Minify

I usually tend to use an `$options` var to customize my classes easily.

it's a three blocks of code thing:

- First it's the $Options variable ([Preview](https://github.com/emadha/minify/blob/1eb8528718cb8be1975a97156ecaa80a0af2825b/src/Minify.php#L30-L42))
- Second is the setOptions($key, $value) method \returns the class instance ([Preview](https://github.com/emadha/minify/blob/1eb8528718cb8be1975a97156ecaa80a0af2825b/src/Minify.php#L44-L65))
- Third is where the condition is meant to be used ([Preview](https://github.com/emadha/minify/blob/1eb8528718cb8be1975a97156ecaa80a0af2825b/src/CSS.php#L315-L328)).

In the CSS class for instance, i saw methods like `stripWhitespace`, but what if the user doesn't want to strip those spaces? the solution will be editing the **CSS** class and that's not what developers want.

so adding a condition before using methods as `$this->stripWhitespaces($css)`
```
if ($this->options['css-strip-whitespace'] === true)
          $css = $this->stripWhitespace($css);
```

will effectively disable removing whitespaces.

this will not change the way people use Minify, but will add a new method on the go.

```
...
// save minified file to disk
$minifiedPath = '/path/to/minified/css/file.css';

$minifier->setOptions('css-strip-whitespace', false); // will disable removing white spaces
```
and the options key can be array as well:
```
$minifier->setOptions([
        'css-strip-whitespace'=>false,
        'css-shorten-hex'=>false,
        ...
    ]); // will disable removing white & hex shortening 

$minifier->minify($minifiedPath);`
```

and since the setOptions returns the class instance we can do this:

```
$minifier->setOptions('key','value')
         ->minify($minifiedPath);
```
i hope you find this useful