### PR TITLE
Correcting "Undefined offset: 0"

### DIFF
--- a/src/Minify.php
+++ b/src/Minify.php
@@ -241,7 +241,7 @@ abstract class Minify
 
                 // no need to re-run matches that are still in the part of the
                 // content that hasn't been processed
-                if ($positions[$i] >= 0) {
+                if (isset($positions[$i])  &&  $positions[$i] >= 0) {
                     continue;
                 }
 


### PR DESCRIPTION
https://github.com/matthiasmullie/minify/commit/04a37f5434c618cae16a7dca13592a567bc36246 caused a regression by unsetting $positions followed by an array index read which fails with "Undefined offset: 0"