### PR TITLE
Fixes #274 Correctly minify CSS with multiple calc() on the same line

### DIFF
--- a/src/CSS.php
+++ b/src/CSS.php
@@ -708,7 +708,7 @@ class CSS extends Minify
             return $placeholder.$rest;
         };
 
-        $this->registerPattern('/calc(\(.+?)(?=$|;|calc\()/', $callback);
+        $this->registerPattern('/calc(\(.+?)(?=$|;|calc\()/m', $callback);
     }
 
     /**

--- a/tests/css/CSSTest.php
+++ b/tests/css/CSSTest.php
@@ -494,6 +494,17 @@ only screen and (min-device-pixel-ratio: 1.5) {
             'p{width:calc(35% + (10% + 0px + 10%))}',
         );
 
+		// https://github.com/matthiasmullie/minify/issues/274
+		$tests[] = array(
+	      	'.cvp-live-filter select {
+  background-position:
+    calc(100% - 20px) calc(1em + 2px),
+    calc(100% - 15px) calc(1em + 2px),
+    calc(100% - 2.5em) 0.5em;
+}',
+	      	'.cvp-live-filter select{background-position:calc(100% - 20px) calc(1em + 2px),calc(100% - 15px) calc(1em + 2px),calc(100% - 2.5em) .5em}',    
+        );
+
         // https://github.com/matthiasmullie/minify/issues/139
         $tests[] = array(
             __DIR__.'/sample/line_endings/lf/parent.css',


### PR DESCRIPTION
Uses the multilines `m` flag for the pattern used in `extractCalcs()`