### PR TITLE
PHP 7.4 Implode warning

### DIFF
--- a/src/CSS.php
+++ b/src/CSS.php
@@ -525,7 +525,7 @@ class CSS extends Minify
         );
 
         return preg_replace_callback(
-            '/(?<=[: ])('.implode(array_keys($colors), '|').')(?=[; }])/i',
+            '/(?<=[: ])('.implode('|', array_keys($colors)).')(?=[; }])/i',
             function ($match) use ($colors) {
                 return $colors[strtoupper($match[0])];
             },


### PR DESCRIPTION
Fixes the implode warning in PHP 7.4