### PR TITLE
[CSS.php] implode glue string before array

### DIFF
--- a/src/CSS.php
+++ b/src/CSS.php
@@ -525,7 +525,7 @@ class CSS extends Minify
         );
 
         return preg_replace_callback(
-            '/(?<=[: ])('.implode(array_keys($colors), '|').')(?=[; }])/i',
+            '/(?<=[: ])('.implode('|', array_keys($colors)).')(?=[; }])/i',
             function ($match) use ($colors) {
                 return $colors[strtoupper($match[0])];
             },


### PR DESCRIPTION
Glue string after the array is deprecated. Swap parameters.