### PR TITLE
split on preserved comments before running minification, fixes #222

### DIFF
--- a/src/CSS.php
+++ b/src/CSS.php
@@ -295,30 +295,60 @@ class CSS extends Minify
      */
     public function execute($path = null, $parents = array())
     {
-        $content = '';
+        $preservecommentpattern = '/(
+            # optional newline
+            \n?
+            # start comment
+            \/\*
+            # comment content
+            (?:
+                # either starts with an !
+                !
+            |
+                # or, after some number of characters which do not end the comment
+                (?:(?!\*\/).)*?
+                # there is either a @license or @preserve tag
+                @(?:license|preserve)
+            )
+            # then match to the end of the comment
+            .*?\*\/\n?
+            )/ixs';
 
         // loop CSS data (raw data and files)
         foreach ($this->data as $source => $css) {
-            /*
-             * Let's first take out strings & comments, since we can't just
-             * remove whitespace anywhere. If whitespace occurs inside a string,
-             * we should leave it alone. E.g.:
-             * p { content: "a   test" }
-             */
-            $this->extractStrings();
-            $this->stripComments();
-            $this->extractCalcs();
-            $css = $this->replace($css);
+            // Split JS on special comments.
+            $chunks = preg_split($preservecommentpattern, $css, -1, PREG_SPLIT_DELIM_CAPTURE );
+            $processed = [];
+            for ($i = 0; $i < count($chunks); $i += 2) {
+                $code = $chunks[$i];
+                $comment = '';
+                if (isset($chunks[$i + 1])) {
+                    $comment = $chunks[$i + 1];
+                }
+                /*
+                * Let's first take out strings & other comments, since we can't just
+                * remove whitespace anywhere. If whitespace occurs inside a string,
+                * we should leave it alone. E.g.:
+                * p { content: "a   test" }
+                */
+                $this->extractStrings();
+                $this->stripComments();
+                $this->extractCalcs();
+                $code = $this->replace($code);
 
-            $css = $this->stripWhitespace($css);
-            $css = $this->shortenColors($css);
-            $css = $this->shortenZeroes($css);
-            $css = $this->shortenFontWeights($css);
-            $css = $this->stripEmptyTags($css);
+                $code = $this->stripWhitespace($code);
+                $code = $this->shortenColors($code);
+                $code = $this->shortenZeroes($code);
+                $code = $this->shortenFontWeights($code);
+                $code = $this->stripEmptyTags($code);
 
-            // restore the string we've extracted earlier
-            $css = $this->restoreExtractedData($css);
+                // restore the string we've extracted earlier
+                $code = $this->restoreExtractedData($code);
 
+                $processed[] = $code;
+                $processed[] = $comment;
+            }
+            $css = implode($processed);
             $source = is_int($source) ? '' : $source;
             $parents = $source ? array_merge($parents, array($source)) : $parents;
             $css = $this->combineImports($source, $css, $parents);
@@ -335,9 +365,9 @@ class CSS extends Minify
             $css = $this->move($converter, $css);
 
             // combine css
-            $content .= $css;
+            $content[] = $css;
         }
-
+        $content = implode($content);
         $content = $this->moveImportsToTop($content);
 
         return $content;
@@ -627,17 +657,6 @@ class CSS extends Minify
      */
     protected function stripComments()
     {
-        // PHP only supports $this inside anonymous functions since 5.4
-        $minifier = $this;
-        $callback = function ($match) use ($minifier) {
-            $count = count($minifier->extracted);
-            $placeholder = '/*'.$count.'*/';
-            $minifier->extracted[$placeholder] = $match[0];
-
-            return $placeholder;
-        };
-        $this->registerPattern('/\n?\/\*(!|.*?@license|.*?@preserve).*?\*\/\n?/s', $callback);
-
         $this->registerPattern('/\/\*.*?\*\//s', '');
     }
 

--- a/src/CSS.php
+++ b/src/CSS.php
@@ -727,7 +727,6 @@ class CSS extends Minify
             return $placeholder.$rest;
         };
 
-        $this->registerPattern('/calc(\(.+?)(?=$|;|}|calc\()/', $callback);
         $this->registerPattern('/calc(\(.+?)(?=$|;|}|calc\()/m', $callback);
     }
 

--- a/src/JS.php
+++ b/src/JS.php
@@ -204,6 +204,7 @@ class JS extends Minify
                 $processed[] = $comment;
             }
             $file = implode($processed);
+            // ASI at end of file, will be added back if concatenated later.
             $file = preg_replace('/;$/s', '', $file);
 
             $files[] = $file;

--- a/src/Minify.php
+++ b/src/Minify.php
@@ -105,7 +105,7 @@ abstract class Minify
      * @param string|string[] $data
      *
      * @return static
-     * 
+     *
      * @throws IOException
      */
     public function addFile($data /* $data = null, ... */)
@@ -268,7 +268,7 @@ abstract class Minify
      */
     protected function replace($content)
     {
-        $processed = '';
+        $processed = [];
         $positions = array_fill(0, count($this->patterns), -1);
         $matches = array();
 
@@ -307,7 +307,7 @@ abstract class Minify
 
             // no more matches to find: everything's been processed, break out
             if (!$matches) {
-                $processed .= $content;
+                $processed[] = $content;
                 break;
             }
 
@@ -317,6 +317,7 @@ abstract class Minify
             $discardLength = min($positions);
             $firstPattern = array_search($discardLength, $positions);
             $match = $matches[$firstPattern][0][0];
+            $matchlen = strlen($match);
 
             // execute the pattern that matches earliest in the content string
             list($pattern, $replacement) = $this->patterns[$firstPattern];
@@ -325,22 +326,22 @@ abstract class Minify
             // figure out which part of the string was unmatched; that's the
             // part we'll execute the patterns on again next
             $content = (string) substr($content, $discardLength);
-            $unmatched = (string) substr($content, strpos($content, $match) + strlen($match));
+            $unmatched = (string) substr($content, strpos($content, $match) + $matchlen);
 
             // move the replaced part to $processed and prepare $content to
             // again match batch of patterns against
-            $processed .= substr($replacement, 0, strlen($replacement) - strlen($unmatched));
+            $processed[] = substr($replacement, 0, strlen($replacement) - strlen($unmatched));
             $content = $unmatched;
 
             // first match has been replaced & that content is to be left alone,
             // the next matches will start after this replacement, so we should
             // fix their offsets
             foreach ($positions as $i => $position) {
-                $positions[$i] -= $discardLength + strlen($match);
+                $positions[$i] -= $discardLength + $matchlen;
             }
         }
 
-        return $processed;
+        return implode($processed);
     }
 
     /**


### PR DESCRIPTION
Okay, I'll admit up front that I'm not actually sure *exactly* what the problem was that caused the issue described in #222, but this first commit seems to fix it for me an an effected server and I have a reasonable intuition of why that makes sense.

I've included @timhunts regex fix for #333 in this, since that regex is pretty key to this and seems to be more reliably correct with his update. So this also has the better output (no longer accidentally skipping some minification opportunities) of that PR.

I think this change should help in some rare, extreme cases where people are minifying giant files, but also shouldn't have any bad effect on more normal usage.

In the test file for #222, and I'd guess many other times when you end up with >1MB javascript files, which is the size where it seems to start mattering, it will be because you have pre-concatenated the seperate files, and many of those will have comments they wish preserved.

Previously, preserved comments where extracted from the file and replaced with a counter, and then injected back into the same places later on in the process. To avoid the memory paging/swapping behaviour that I believe contributes to #222 I wanted to split the large file up and process each one individually. Since the minifications shouldn't cross the boundary of these extracted comments, they seemed like a good place to split. And since they're just a special kind of CSS comment, they could also be added manually to break up large files. (I did look at more brutally chopping up the input into byte chunks to see if there was a sweet spot in size but wasn't as confident that wouldn't cause issues and as long as the chunks remain below about 850K you seem to get the benefit)

Side note: the library itself already supports passing individual files in one at a time and minifying them in one go, which is as fast as this approach and a good workaround if you control the input going into the library, in some cases it might be easier or make more sense just to pass in the individual files one at a time in the first place rather than concatenate them just for the minification process to split them up again and then recombine them. Might be worth noting that in the documentation somewhere so people can avoid hitting this issue.

As far as I can tell, when you pass the large file as a single piece then the repeated substr (and possibly the regex, though I think the C implementation of those may be so optimised that it doesn't matter) on these long strings creates a lot of memory churn and this can slow things down as files get bigger. There's no memory leak as such, it just burns through a lot of quickly disposible strings. This causes slowness on most servers as the file size increases but can be a showstopper on weak/overloaded servers (in the latter case adding a degree of unpredictably too).

This patch tries to mimick that behaviour when the input is out of your control. Rather than extracting the preserved comments at the same time as the other search and replaces, it does it first with a preg_split and then deals with the file as the resulting chunks of code / comment / code / comment / code / comment, minifying the code ones before stitching them back together.

I'm hoping that keeping the output of the minification process as arrays of non-modified strings as much as possible will help further with the memory usage / speed, though I've kept that to a seperate commit and it's hard to see/measure much benefit of that seperate from the other change.

While running this with some diagnostic output (from Tim Hunt's patch for Moodle) I noticed that two very similar regexes were getting run the same number of times after each other. I believe the first one is redundant if you're also running the second one, that's the 3rd commit.