### PR TITLE
Add support for box to generate PHAR binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ composer require matthiasmullie/minify
 
 Although it's recommended to use Composer, you can actually [include these files](https://github.com/matthiasmullie/minify/issues/83) anyway you want.
 
+It's possible to generate PHAR binary using [box utility](https://github.com/humbug/box).
+
 
 ## Try it
 

--- a/bin/minify
+++ b/bin/minify
@@ -1,0 +1,48 @@
+#!/usr/bin/env php
+<?php
+use MatthiasMullie\Minify;
+
+// command line utility to minify JS and CSS
+require_once __DIR__ . '/../vendor/autoload.php';
+
+error_reporting(E_ALL);
+// check PHP setup for cli arguments
+if (!isset($_SERVER['argv']) && !isset($argv)) {
+    fwrite(STDERR, 'Please enable the "register_argc_argv" directive in your php.ini' . PHP_EOL);
+    exit(1);
+} elseif (!isset($argv)) {
+    $argv = $_SERVER['argv'];
+}
+// check if path to file given
+if (!isset($argv[1])) {
+    fwrite(STDERR, 'Argument expected: path to file' . PHP_EOL);
+    exit(1);
+}
+// check if script run in cli environment
+if ('cli' !== php_sapi_name()) {
+    fwrite(STDERR, $argv[1] . ' must be run in the command line' . PHP_EOL);
+    exit(1);
+}
+// check if source file exists
+if (!file_exists($argv[1])) {
+    fwrite(STDERR, 'Source file "' . $argv[1] . '" not found' . PHP_EOL);
+    exit(1);
+}
+
+try {
+    switch (strtolower(pathinfo($argv[1], PATHINFO_EXTENSION))) {
+        case 'js':
+            $minifier = new Minify\JS($argv[1]);
+            break;
+        case 'css':
+            $minifier = new Minify\CSS($argv[1]);
+            break;
+        default:
+            fwrite(STDERR, 'File "' . $argv[1] . '" is not supported' . PHP_EOL);
+            exit(1);
+    }
+    echo $minifier->minify();
+} catch (Exception $e) {
+    fwrite(STDERR, $e->getMessage(), PHP_EOL);
+    exit(1);
+}

--- a/box.json
+++ b/box.json
@@ -1,0 +1,5 @@
+{
+    "main": "bin/minify",
+    "directories-bin": ["data"],
+    "force-autodiscovery": true
+}


### PR DESCRIPTION
This PR introduces new command `bin/minify` which includes functionality of `minifycss` and `minifyjs` scripts, detecting file type using file extension just for simplicity. Also, this PR adds configuration file for box: https://github.com/humbug/box. Thanks to box it's possible to generate handy one-file command for minifying both JS and CSS files. Just install box https://github.com/humbug/box/blob/master/doc/installation.md#installation and run `box build` in root directory.