### PR TITLE
Added possibility to define base path for resources

### DIFF
--- a/src/CSS.php
+++ b/src/CSS.php
@@ -262,7 +262,7 @@ class CSS extends Minify
 
                 // get the path for the file that will be imported
                 $path = $match[2];
-                $path = dirname($source).'/'.$path;
+                $path = $this->resourcesBasePath . dirname($source).'/'.$path;
 
                 // only replace the import with the content if we're able to get
                 // the content of the file, and it's relatively small

--- a/src/Minify.php
+++ b/src/Minify.php
@@ -49,6 +49,15 @@ abstract class Minify
     public $extracted = array();
 
     /**
+     * Path from where resources like images, fonts etc. can be imported.
+     * Minify will be default look for resources based on its path defined in CSS,
+     * if your structure of files is different because of different folder structure,
+     * you can specify base directory.
+     * @var string
+     */
+    protected $resourcesBasePath = "";
+
+    /**
      * Init the minify class - optionally, code may be passed along already.
      */
     public function __construct(/* $data = null, ... */)
@@ -105,7 +114,7 @@ abstract class Minify
      * @param string|string[] $data
      *
      * @return static
-     * 
+     *
      * @throws IOException
      */
     public function addFile($data /* $data = null, ... */)
@@ -190,6 +199,18 @@ abstract class Minify
         $item->set($content);
 
         return $item;
+    }
+
+    /**
+     * Path from where resources like images, fonts etc. can be imported.
+     * Minify will be default look for resources based on its path defined in CSS,
+     * if your structure of files is different because of different folder structure,
+     * you can specify base directory.
+     * @var string
+     */
+    public function setResourcesBasePath(string $path)
+    {
+        $this->resourcesBasePath = $path;
     }
 
     /**


### PR DESCRIPTION
Currently resources like images are loaded base on path in CSS file, in case there is different folder structure and www directory, it is not possible to use import feature. This will allow to specify base path for resources.