### PR TITLE
Fix #316 Replacing 'white' and 'black' to '#fff' and '#000' breaks fonts

### DIFF
--- a/src/CSS.php
+++ b/src/CSS.php
@@ -525,7 +525,7 @@ class CSS extends Minify
         );
 
         return preg_replace_callback(
-            '/(?<=[: ])('.implode('|', array_keys($colors)).')(?=[; }])/i',
+            '/(?<=[:])(?<!font-family:)('.implode('|', array_keys($colors)).')(?=[; }])/i',
             function ($match) use ($colors) {
                 return $colors[strtoupper($match[0])];
             },

--- a/tests/css/CSSTest.php
+++ b/tests/css/CSSTest.php
@@ -818,6 +818,32 @@ body{font-family:sans-serif}',
             'ul p{padding-left:calc((var(--icon-size) / 2) + var(--horisontal-space))}',
         );
 
+        // https://github.com/matthiasmullie/minify/issues/316
+        $tests[] = array(
+            '@font-face { font-family: "Circular Std Black"; src: url(my_black_font.woff); }',
+            '@font-face{font-family:"Circular Std Black";src:url(my_black_font.woff)}',
+        );
+        $tests[] = array(
+            '@font-face { font-family: \'Circular Std White\'; src: url(my_white_font.woff); }',
+            '@font-face{font-family:\'Circular Std White\';src:url(my_white_font.woff)}',
+        );
+        $tests[] = array(
+            '@font-face { font-family: Circular Std Black; src: url(my_black_font.woff); }',
+            '@font-face{font-family:Circular Std Black;src:url(my_black_font.woff)}',
+        );
+        $tests[] = array(
+            '@font-face { font-family: Circular Std White; src: url(my_white_font.woff); }',
+            '@font-face{font-family:Circular Std White;src:url(my_white_font.woff)}',
+        );
+        $tests[] = array(
+            '@font-face { font-family: Black; src: url(my_black_font.woff); }',
+            '@font-face{font-family:Black;src:url(my_black_font.woff)}',
+        );
+        $tests[] = array(
+            '@font-face { font-family: White; src: url(my_white_font.woff); }',
+            '@font-face{font-family:White;src:url(my_white_font.woff)}',
+        );
+
         return $tests;
     }
 

--- a/tests/css/CSSTest.php
+++ b/tests/css/CSSTest.php
@@ -759,6 +759,24 @@ body{font-family:sans-serif}',
             '@import url(http://minify.dev/?a=1&amp;b=some/*lala*/thing);p{color:red}body{font-family:sans-serif}',
         );
 
+        // https://github.com/matthiasmullie/minify/pull/258
+        $tests[] = array(
+            'color:white;',
+            'color:#fff;',
+        );
+        $tests[] = array(
+            'color:black;',
+            'color:#000;',
+        );
+        $tests[] = array(
+            'background:white;',
+            'background:#fff;',
+        );
+        $tests[] = array(
+            'background:black;',
+            'background:#000;',
+        );
+
         // https://github.com/matthiasmullie/minify/issues/259
         $tests[] = array(
             '#layout-newsletter-change .unsubscribe :checked + label .circle, #layout-newsletter-change .pause : checked + label .circle { color: white }',


### PR DESCRIPTION
Prevents hex color changes from being applied to `font-family` properties.
Tests added to both #316 and #258.

Fixes #316 