### PR TITLE
Fix #329 Prevent regex from getting stripped as comment

### DIFF
--- a/src/JS.php
+++ b/src/JS.php
@@ -209,7 +209,7 @@ class JS extends Minify
         $this->registerPattern('/\/\*.*?\*\//s', '');
 
         // single-line comments
-        $this->registerPattern('/\/\/.*$/m', '');
+        $this->registerPattern('/(\/\/)(?!i).*$/m', '');
     }
 
     /**

--- a/tests/js/JSTest.php
+++ b/tests/js/JSTest.php
@@ -1324,6 +1324,24 @@ var largeScreen=2048',
             '/^\[(x| )\](?=\s)/i',
         );
 
+        // https://github.com/matthiasmullie/minify/issues/323
+        $tests[] = array(
+            'a = {
+                device: [
+                    [/android.+(transfo[prime\s]{4,10}\s\w+|eeepc|slider\s\w+|nexus 7)/i],
+                    [/(sony)\s(tablet\s[ps])\sbuild\//i, /(sony)?(?:sgp.+)\sbuild\//i],
+                    [/(?:sony)?(?:(?:(?:c|d)\d{4})|(?:so[-l].+))\sbuild\//i]
+                ]
+            }',
+            'a={device:[[/android.+(transfo[prime\s]{4,10}\s\w+|eeepc|slider\s\w+|nexus 7)/i],[/(sony)\s(tablet\s[ps])\sbuild\//i,/(sony)?(?:sgp.+)\sbuild\//i],[/(?:sony)?(?:(?:(?:c|d)\d{4})|(?:so[-l].+))\sbuild\//i]]}'
+        );
+
+        // https://github.com/matthiasmullie/minify/issues/329
+        $tests[] = array(
+            'test: [/\sedg\//i],',
+            'test:[/\sedg\//i],',
+        );
+
         // known minified files to help doublecheck changes in places not yet
         // anticipated in these tests
         $files = glob(__DIR__.'/sample/minified/*.js');


### PR DESCRIPTION
This a quick fix that will solve some issues but prevent the removal of single line comments starting with "//i". I guess it's better to leave some comments than breaking the code.

Fixes #323 and #329.