### PR TITLE
Don't strip semicolons after closing parentheses

### DIFF
--- a/src/JS.php
+++ b/src/JS.php
@@ -432,7 +432,7 @@ class JS extends Minify
          * script: ASI will kick in here & we're all about minifying.
          * Semicolons at beginning of the file don't make any sense either.
          */
-        $content = preg_replace('/;(\}|$)/s', '\\1', $content);
+        $content = preg_replace('/(?<!\));(\}|$)/s', '\\1', $content);
         $content = ltrim($content, ';');
 
         // get rid of remaining whitespace af beginning/end


### PR DESCRIPTION
The regex to clean up semi-colons does not take into account that it may be after a function call.

A small sample from an already minified bundle is `break"!==n(););},Ur)`. Adding a negative lookbehind fixes this.