### PR TITLE
Fixed issue with "url(""); ... any other css code .. url("file.jpg"); in one line

### DIFF
--- a/src/CSS.php
+++ b/src/CSS.php
@@ -248,7 +248,7 @@ class CSS extends Minify
      */
     protected function importFiles($source, $content)
     {
-        $regex = '/url\((["\']?)(.+?)\\1\)/i';
+        $regex = '/url\((["\']?)([^")]+?\\1\)/i';
         if ($this->importExtensions && preg_match_all($regex, $content, $matches, PREG_SET_ORDER)) {
             $search = array();
             $replace = array();


### PR DESCRIPTION
For CSS files with `url("")` and any other url() within one line, the second file was ignored.

See https://regex101.com/r/IkhmxT/2

Sure, "url()" is invalid CSS syntax, but this should be ignored and other URLs in the same line should get handled correctly.