### PR TITLE
reverse arguments for implode() call in extractMath()

### DIFF
--- a/src/CSS.php
+++ b/src/CSS.php
@@ -685,7 +685,7 @@ class CSS extends Minify
     protected function extractMath()
     {
         $functions = array('calc', 'clamp', 'min', 'max');
-        $pattern = '/('. implode($functions, '|') .')(\(.+?)(?=$|;|})/m';
+        $pattern = '/('. implode('|', $functions) .')(\(.+?)(?=$|;|})/m';
 
         // PHP only supports $this inside anonymous functions since 5.4
         $minifier = $this;


### PR DESCRIPTION
Fixes regression from 022cd72 (1.3.64)

Resolves #352

`implode()` argument order is no longer auto-corrected with PHP 8.

