### PR TITLE
Update FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,6 +1,6 @@
 # These are supported funding model platforms
 
-github: [matthiasmullie] # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+github: [matthiasmullie] 
 patreon: # Replace with a single Patreon username
 open_collective: # Replace with a single Open Collective username
 ko_fi: # Replace with a single Ko-fi username


### PR DESCRIPTION
File does not support comments in filled in lines, which causes composer to return 
matthiasmullie
  minify
    https://github.com/sponsors/[user1
    https://github.com/sponsors/matthiasmullie] # Replace with up to 4 GitHub Sponsors-enabled usernames e.g.
    https://github.com/sponsors/user2

if fundinginfo is dumped. Removing the comment should resolve the issue.