### PR TITLE
Backslashed @import comment

### DIFF
--- a/src/CSS.php
+++ b/src/CSS.php
@@ -102,7 +102,7 @@ class CSS extends Minify
     /**
      * Combine CSS from import statements.
      *
-     * @import's will be loaded and their content merged into the original file,
+     * \@import's will be loaded and their content merged into the original file,
      * to save HTTP requests.
      *
      * @param string   $source  The file to combine imports for


### PR DESCRIPTION
reflection-docblock treats this as a tag "does not seem to be wellformed, please check it for  errors"
Backlashing ensures this non-import is ignored.