### PR TITLE
Add an option to CSS Minifyer to not modify relative import paths.

### DIFF
--- a/src/CSS.php
+++ b/src/CSS.php
@@ -34,6 +34,11 @@ class CSS extends Minify
     protected $maxImportSize = 5;
 
     /**
+     * @var bool Allow the modification of the import relative paths
+     */
+    protected $modifyImportPath = true;
+
+    /**
      * @var string[] valid import extensions
      */
     protected $importExtensions = array(
@@ -66,6 +71,18 @@ class CSS extends Minify
     public function setMaxImportSize($size)
     {
         $this->maxImportSize = $size;
+    }
+
+
+    /**
+     * Permit the adjustment of the relative import paths (on by default)
+     *
+     *
+     * @param bool $size Size in kB
+     */
+    public function setModifyImportPath($allow)
+    {
+        $this->modifyImportPath = $allow;
     }
 
     /**
@@ -336,8 +353,10 @@ class CSS extends Minify
              * conversion happens (because we still want it to go through most
              * of the move code, which also addresses url() & @import syntax...)
              */
-            $converter = $this->getPathConverter($source, $path ?: $source);
-            $css = $this->move($converter, $css);
+            if ( $this->modifyImportPath ) {
+                $converter = $this->getPathConverter($source, $path ?: $source);
+                $css = $this->move($converter, $css);
+            }
 
             // combine css
             $content .= $css;

--- a/src/CSS.php
+++ b/src/CSS.php
@@ -73,10 +73,8 @@ class CSS extends Minify
         $this->maxImportSize = $size;
     }
 
-
     /**
-     * Permit the adjustment of the relative import paths (on by default)
-     *
+     * Permit the adjustment of the relative import paths (on by default).
      *
      * @param bool $size Size in kB
      */
@@ -353,7 +351,7 @@ class CSS extends Minify
              * conversion happens (because we still want it to go through most
              * of the move code, which also addresses url() & @import syntax...)
              */
-            if ( $this->modifyImportPath ) {
+            if ($this->modifyImportPath) {
                 $converter = $this->getPathConverter($source, $path ?: $source);
                 $css = $this->move($converter, $css);
             }


### PR DESCRIPTION
Hello. 

I have been testing a new method for minifying the entire project, but not merging it. (Creating a minifyed copy of the directory). 

The CSS minifyer always tries to adjust according to the ending path, unknowing what the final result is intended to be, so the end result is unusable. 

While I understand the reasoning behind adjusting the relative paths, I would like it to be an option (with default value the current behavior), so I created a function to set the non convert path option.

I created this pull request for your consideration.

Have a nice day.