### PR TITLE
PHP 8.2 deprecation fix for "parent::__construct" call

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Test PHP 8.2
+        run: make test PHP=8.2
       - name: Test PHP 8.1
         run: make test PHP=8.1
       - name: Test PHP 8.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Test PHP 8.2
-        run: make test PHP=8.2
+        run: make test PHP=8.2-rc
       - name: Test PHP 8.1
         run: make test PHP=8.1
       - name: Test PHP 8.0

--- a/src/JS.php
+++ b/src/JS.php
@@ -127,7 +127,10 @@ class JS extends Minify
      */
     public function __construct()
     {
-        parent::__construct(func_get_args());
+        // Can't just call parent::__construct()
+        if (func_num_args()) {
+            parent::__construct(func_get_args());
+        }
 
         $dataDir = __DIR__ . '/../data/js/';
         $options = FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES;
@@ -182,7 +185,7 @@ class JS extends Minify
 
         // clean up leftover `;`s from the combination of multiple scripts
         $content = ltrim($content, ';');
-        $content = (string) substr($content, 0, -1);
+        $content = (string)substr($content, 0, -1);
 
         /*
          * Earlier, we extracted strings & regular expressions and replaced them
@@ -266,7 +269,7 @@ class JS extends Minify
         // a regular expression can only be followed by a few operators or some
         // of the RegExp methods (a `\` followed by a variable or value is
         // likely part of a division, not a regex)
-        $keywords = array('do', 'in', 'new', 'else', 'throw', 'yield', 'delete', 'return',  'typeof');
+        $keywords = array('do', 'in', 'new', 'else', 'throw', 'yield', 'delete', 'return', 'typeof');
         $before = '(^|[=:,;\+\-\*\?\/\}\(\{\[&\|!]|' . implode('|', $keywords) . ')\s*';
         $propertiesAndMethods = array(
             // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp#Properties_2
@@ -474,7 +477,7 @@ class JS extends Minify
      * This will prepare the given array by escaping all characters.
      *
      * @param string[] $operators
-     * @param string   $delimiter
+     * @param string $delimiter
      *
      * @return string[]
      */
@@ -505,7 +508,7 @@ class JS extends Minify
      * This will prepare the given array by escaping all characters.
      *
      * @param string[] $keywords
-     * @param string   $delimiter
+     * @param string $delimiter
      *
      * @return string[]
      */

--- a/src/JS.php
+++ b/src/JS.php
@@ -127,7 +127,7 @@ class JS extends Minify
      */
     public function __construct()
     {
-        call_user_func_array(array('parent', '__construct'), func_get_args());
+        parent::__construct(func_get_args());
 
         $dataDir = __DIR__ . '/../data/js/';
         $options = FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES;

--- a/src/JS.php
+++ b/src/JS.php
@@ -185,7 +185,7 @@ class JS extends Minify
 
         // clean up leftover `;`s from the combination of multiple scripts
         $content = ltrim($content, ';');
-        $content = (string)substr($content, 0, -1);
+        $content = (string) substr($content, 0, -1);
 
         /*
          * Earlier, we extracted strings & regular expressions and replaced them
@@ -269,7 +269,7 @@ class JS extends Minify
         // a regular expression can only be followed by a few operators or some
         // of the RegExp methods (a `\` followed by a variable or value is
         // likely part of a division, not a regex)
-        $keywords = array('do', 'in', 'new', 'else', 'throw', 'yield', 'delete', 'return', 'typeof');
+        $keywords = array('do', 'in', 'new', 'else', 'throw', 'yield', 'delete', 'return',  'typeof');
         $before = '(^|[=:,;\+\-\*\?\/\}\(\{\[&\|!]|' . implode('|', $keywords) . ')\s*';
         $propertiesAndMethods = array(
             // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp#Properties_2
@@ -477,7 +477,7 @@ class JS extends Minify
      * This will prepare the given array by escaping all characters.
      *
      * @param string[] $operators
-     * @param string $delimiter
+     * @param string   $delimiter
      *
      * @return string[]
      */
@@ -508,7 +508,7 @@ class JS extends Minify
      * This will prepare the given array by escaping all characters.
      *
      * @param string[] $keywords
-     * @param string $delimiter
+     * @param string   $delimiter
      *
      * @return string[]
      */


### PR DESCRIPTION
Treating `array('parent', '__construct')` as callable is no longer allowed in PHP 8.2.