### PR TITLE
Added functionality to remove code after a /*DEV*/ comment

### DIFF
--- a/src/JS.php
+++ b/src/JS.php
@@ -195,6 +195,12 @@ class JS extends Minify
      */
     protected function stripComments()
     {
+        // enable removal of /*DEV*/ style comments
+        // this pattern will replace from "/*DEV*/" to end of line - e.g. "/*DEV*/ console.log(data);" -> ""
+        // it needs to come before the call to stripMultilineComments, otherwise that deletes
+        // the crucial /*DEV*/, while leaving the rest of the line entact
+        $this->registerPattern('/\/\*DEV\*\/.*$/m', '');
+        
         $this->stripMultilineComments();
 
         // single-line comments


### PR DESCRIPTION
I can see that back in Nov 2017 @tetrode added a similar PR that never got merged.  Hopefully this one will.

(This is my first ever OSS contribution and pull request, so apologies if I've done it wrong...!)