### PR TITLE
Drop PHP 5.4 from tests.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,8 +33,6 @@ jobs:
         run: make test PHP=5.6
       - name: Test PHP 5.5
         run: make test PHP=5.5
-      - name: Test PHP 5.4
-        run: make test PHP=5.4
       - uses: codecov/codecov-action@v3
         with:
           directory: build


### PR DESCRIPTION
The PHP 5.4 container cannot be loaded anymore (see https://github.com/matthiasmullie/minify/pull/444/checks).